### PR TITLE
Allow configuring which python interpreters are tried in PythonFinder

### DIFF
--- a/docs/latest.markdown
+++ b/docs/latest.markdown
@@ -174,6 +174,27 @@ section of the configuration file.
 
   - `true` - cache highlighting results
   - `false` - do not cache highlighting results
+
+#####Python command selection
+
+If you're getting errors like this:
+```
+  File "mentos.py", line 11, in <module>
+    import pygments
+  File "/.../.grain/tools/.../pygments-main/pygments/__init__.py", line 46
+    except TypeError, err:
+```
+then your system probably defaults to Python 3, which is incompatible with the bundled version of Pygments.
+
+By default, `python` and `python2.7` are tried, in that order. To try other python command names first, add a `python`
+section in the `features` section with a `cmd_candidates` list of python interpreters, like so:
+```
+features {
+    python {
+        cmd_candidates = ['python2', 'some-other-python', 'yet-another-python']
+    }
+}
+```
   
 ####SASS/Compass feature
 

--- a/src/main/groovy/com/sysgears/grain/highlight/HighlightModule.groovy
+++ b/src/main/groovy/com/sysgears/grain/highlight/HighlightModule.groovy
@@ -18,12 +18,14 @@ package com.sysgears.grain.highlight
 
 import com.google.inject.AbstractModule
 import com.google.inject.Provides
+import com.google.inject.Scopes
 import com.sysgears.grain.annotations.Uncached
 import com.sysgears.grain.config.Config
 import com.sysgears.grain.highlight.pygments.AutoPygments
 import com.sysgears.grain.highlight.pygments.FakePygments
 import com.sysgears.grain.highlight.pygments.JythonPygments
 import com.sysgears.grain.highlight.pygments.Pygments
+import com.sysgears.grain.highlight.pygments.PythonFinder
 import com.sysgears.grain.highlight.pygments.PythonPygments
 import com.sysgears.grain.highlight.pygments.ShellPygments
 import com.sysgears.grain.config.ImplBinder
@@ -59,5 +61,6 @@ class HighlightModule extends AbstractModule {
 
     @Override
     protected void configure() {
+        bind(PythonFinder).in(Scopes.SINGLETON)
     }
 }

--- a/src/main/groovy/com/sysgears/grain/highlight/pygments/AutoPygments.groovy
+++ b/src/main/groovy/com/sysgears/grain/highlight/pygments/AutoPygments.groovy
@@ -16,8 +16,6 @@
 
 package com.sysgears.grain.highlight.pygments
 
-import com.sysgears.grain.compass.RubyFinder
-
 import javax.inject.Inject
 import javax.inject.Named
 
@@ -33,6 +31,8 @@ class AutoPygments extends Pygments {
 
     /** Pygments as a Jython process integration implementation */
     private @Inject JythonPygments jythonPygments
+
+    private @Inject PythonFinder pythonFinder
 
     /** Currently used Pygments integration implementation */
     private Pygments pygments
@@ -50,7 +50,7 @@ class AutoPygments extends Pygments {
      */
     @Override
     public void start() {
-        pygments = PythonFinder.pythonCmd != null ? pythonPygments : jythonPygments
+        pygments = pythonFinder.pythonCmd != null ? pythonPygments : jythonPygments
         pygments.start()
     }
  

--- a/src/main/groovy/com/sysgears/grain/highlight/pygments/PythonFinder.groovy
+++ b/src/main/groovy/com/sysgears/grain/highlight/pygments/PythonFinder.groovy
@@ -1,25 +1,62 @@
 package com.sysgears.grain.highlight.pygments
 
+import com.sysgears.grain.config.Config
+import com.sysgears.grain.preview.ConfigChangeListener
+
+import javax.annotation.Nullable
+import javax.inject.Inject
+
 /**
  * Finder of most appropriate Python version in the system
  */
-public class PythonFinder {
-    
+public class PythonFinder implements ConfigChangeListener {
+
     /** Python command candidates to check */
-    private static final def PYTHON_CANDIDATES = ["python", "python2.7"] 
-    
+    private static final def DEFAULT_PYTHON_CANDIDATES = ['python2', "python", "python2.7"]
+
+    @Nullable
+    private String currentCandidate
+
+    private final Config config
+
+    @Inject
+    PythonFinder(Config config) {
+        this.config = config
+        calculateCandidate()
+    }
+
     /**
-     * Finds most appropriate Ruby command in the system.
+     * Finds most appropriate Python command in the system.
      */
-    public static String getPythonCmd() {
-        def candidates = System.getProperty("os.name").toLowerCase().contains('win') ?
-            PYTHON_CANDIDATES.collect { it + ".exe" } : PYTHON_CANDIDATES
-        candidates.find {
+    @Nullable
+    public String getPythonCmd() {
+        currentCandidate
+    }
+
+    private String calculateCandidate() {
+        def candidates = []
+
+        if (config.features?.python?.cmd_candidates) {
+            candidates.addAll((List)config.python.cmd_candidates)
+        }
+
+        candidates.addAll(DEFAULT_PYTHON_CANDIDATES)
+        candidates = isWindows() ? candidates.collect { it + ".exe" } : candidates
+        currentCandidate = candidates.find {
             try {
                 [it, '-v'].execute()
             } catch (Throwable ignored) {
                 false
             }
         }
+    }
+
+    private static boolean isWindows() {
+        System.getProperty("os.name").toLowerCase().contains('win')
+    }
+
+    @Override
+    void configChanged() {
+        calculateCandidate()
     }
 }

--- a/src/main/groovy/com/sysgears/grain/highlight/pygments/PythonPygments.groovy
+++ b/src/main/groovy/com/sysgears/grain/highlight/pygments/PythonPygments.groovy
@@ -52,6 +52,8 @@ class PythonPygments extends Pygments {
     /** Grain settings */
     @Inject private GrainSettings settings
 
+    @Inject private PythonFinder pythonFinder
+
     /** Process streams logger */
     private StreamLogger streamLogger
 
@@ -151,7 +153,6 @@ class PythonPygments extends Pygments {
     /**
      * @inheritDoc
      */
-    @Override
     public void launchPygments() {
         latch = new CountDownLatch(1)
         thread = Thread.start {
@@ -161,7 +162,7 @@ class PythonPygments extends Pygments {
                 if (bundledPygments) {
                     env += ["PYGMENTS_HOME=${new File(settings.toolsHome, 'pygments-main').canonicalPath}"]
                 }
-                def process = Runtime.runtime.exec([PythonFinder.pythonCmd, "mentos.py"] as String[],
+                def process = Runtime.runtime.exec([pythonFinder.pythonCmd, "mentos.py"] as String[],
                         env as String[],
                         new File(settings.toolsHome, 'mentos'))
                 bos = new BufferedOutputStream(process.out)


### PR DESCRIPTION
It made sense to have PythonFinder just access the config directly from Config, so I made it non-static so that it could implement ConfigChangeListener. Also, I made it cache the results of the lookup to save a few execs.
