### PR TITLE
Added import statement to custom taglib example

### DIFF
--- a/docs/latest.markdown
+++ b/docs/latest.markdown
@@ -840,6 +840,8 @@ The tag lib class constructor should expect one argument - standard Grain taglib
 Example:
 
 ``` groovy:nl SiteConfig.groovy
+import com.example.grain.taglib.MyTagLib
+...
 tag_libs = [OctopressTagLib, MyTagLib]
 ```
 


### PR DESCRIPTION
To use a taglib, its class must be imported into `SiteConfig.groovy`. That may be self-evident to some, but when I created my first taglib the example gave me the impression that Grain was going to find the class on its own. In hindsight, that was rather naive of me, but nevertheless, I want to clarify the example.

