### PR TITLE
Correct a misspelling in a log message

### DIFF
--- a/src/main/groovy/com/sysgears/grain/preview/SitePreviewer.groovy
+++ b/src/main/groovy/com/sysgears/grain/preview/SitePreviewer.groovy
@@ -63,7 +63,7 @@ class SitePreviewer implements Service {
     public void start() {
         def jettyPort = config.jetty_port ?: 4000
         if (!available(jettyPort)) {
-            log.error("Port ${jettyPort} is not available, exitting...")
+            log.error("Port ${jettyPort} is not available, exiting...")
             Thread.startDaemon {
                 System.exit(1)
             }


### PR DESCRIPTION
Spotted this spelling mistake whilst trying to re-use a port!